### PR TITLE
Use collections instead of site.data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jekyll::RemoteCsv [![Build Status](https://travis-ci.org/everypolitician/jekyll-remote_csv.svg?branch=master)](https://travis-ci.org/everypolitician/jekyll-remote_csv)
 
-This plugin allows you to specify remote CSVs to be included in `site.data`. It also provides a way for you to add this data to collection documents.
+This plugin allows you to specify remote CSVs to be turned into collections. It also provides a way for you to associate these collections with other collections.
 
 ## Installation
 
@@ -28,11 +28,17 @@ remote_csv:
     source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
 ```
 
-In this default configuration it will fetch the CSV at the url specified in the source attribute. It will the use the key as the name for the data. In the example above `site.data.education` would be populated with the remote CSV.
+In this default configuration it will fetch the CSV at the url specified in the source attribute. It will the use the key as the name for the collection. In the example above `site.education` would be populated with the remote CSV:
 
-### Adding data to a collection
+```liquid
+{% for item in site.education %}
+  <p>{{ item.role }}</p>
+{% endfor %}
+```
 
-Sometimes you might want this data to be associated with a collection, you can configure this in `_config.yml`:
+### Associating with other collections
+
+Sometimes you might want this collection to be associated with another collection, you can configure this in `_config.yml`:
 
 ```yaml
 remote_csv:
@@ -43,7 +49,7 @@ remote_csv:
       - senate_people
 ```
 
-This will associate the data in the source CSV with the `assembly_people` and `senate_people` collections. For this to work correctly each document in the collections will need to specify an `id` in its frontmatter which matches the `id` column in the CSV. If you need to override this then you can specify that:
+This will associate the collection in the source CSV with the `assembly_people` and `senate_people` collections. For this to work correctly each document in the collections will need to specify an `id` in its frontmatter which matches the `id` column in the CSV. If you need to override this then you can specify that:
 
 ```yaml
 remote_csv:
@@ -69,6 +75,24 @@ Assuming that the CSV file has `person_id`, `organization_name` and `qualificati
   </ul>
 {% endfor %}
 ```
+
+### Outputting a collection
+
+If you want to output the collection then you will need to provide a key to use for the output item's slug.
+
+```yaml
+remote_csv:
+  education:
+    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
+    collection_slug_field: organisation_name
+
+collections:
+  education:
+    output: true
+```
+
+With the above configuration the education source CSV will be turned into a collection and then each item in the collection will be output at `/education/organisation-name-slugified`.
+
 
 ## Development
 

--- a/lib/jekyll/remote_csv.rb
+++ b/lib/jekyll/remote_csv.rb
@@ -15,7 +15,6 @@ module Jekyll
         site.config['remote_csv'].each do |source_name, conf|
           csv_string = open(conf['source']).read
           csv_data = CSV.parse(csv_string, headers: true).map(&:to_hash)
-          site.data[source_name] = csv_data
           site.collections[source_name] = make_collection(site, source_name, conf, csv_data)
           next unless conf['collections']
           conf['collections'].each do |collection_name, key|
@@ -38,7 +37,7 @@ module Jekyll
       def make_collection(site, source_name, conf, csv_data)
         collection = Collection.new(site, source_name)
         csv_data.each do |item|
-          item_id_field = conf.fetch('item_id_field', item.keys.first)
+          item_id_field = conf.fetch('collection_slug_field', item.keys.first)
           path = File.join(site.source, "_#{source_name}", "#{Jekyll::Utils.slugify(item[item_id_field])}.md")
           doc = Document.new(path, collection: collection, site: site)
           doc.merge_data!(item)

--- a/lib/jekyll/remote_csv.rb
+++ b/lib/jekyll/remote_csv.rb
@@ -14,19 +14,40 @@ module Jekyll
         return unless site.config['remote_csv']
         site.config['remote_csv'].each do |source_name, conf|
           csv_string = open(conf['source']).read
-          site.data[source_name] = CSV.parse(csv_string, headers: true).map(&:to_hash)
+          csv_data = CSV.parse(csv_string, headers: true).map(&:to_hash)
+          site.data[source_name] = csv_data
+          site.collections[source_name] = make_collection(site, source_name, conf, csv_data)
           next unless conf['collections']
-          conf['collections'].each do |collection, key|
-            next unless site.collections.key?(collection)
+          conf['collections'].each do |collection_name, key|
+            next unless site.collections.key?(collection_name)
             key ||= 'id'
             csv_id_field = conf.fetch('csv_id_field', 'id')
-            site.collections[collection].docs.each do |person|
-              person.data[source_name] = site.data[source_name].find_all do |item|
-                item[csv_id_field] == person[key]
+            site.collections[collection_name].docs.each do |doc|
+              doc.data[source_name] = site.collections[source_name].docs.find_all do |item|
+                item[csv_id_field] == doc[key]
+              end
+              doc.data[source_name].each do |source_doc|
+                source_doc.data[collection_name] ||= []
+                source_doc.data[collection_name] << doc
               end
             end
           end
         end
+      end
+
+      def make_collection(site, source_name, conf, csv_data)
+        collection = Collection.new(site, source_name)
+        csv_data.each do |item|
+          item_id_field = conf.fetch('item_id_field', item.keys.first)
+          path = File.join(site.source, "_#{source_name}", "#{Jekyll::Utils.slugify(item[item_id_field])}.md")
+          doc = Document.new(path, collection: collection, site: site)
+          doc.merge_data!(item)
+          if site.layouts.key?(source_name)
+            doc.merge_data!('layout' => source_name)
+          end
+          collection.docs << doc
+        end
+        collection
       end
     end
   end

--- a/test/jekyll/remote_csv_test.rb
+++ b/test/jekyll/remote_csv_test.rb
@@ -28,23 +28,28 @@ class Jekyll::RemoteCsvTest < Minitest::Test
   def test_it_populates_site_data_with_education
     site.generate
     refute_nil site.data['education']
+    refute_nil site.collections['education']
   end
 
   def test_the_correct_number_of_records_exist
     site.generate
     assert_equal 9, site.data['education'].size
+    assert_equal 9, site.collections['education'].docs.size
   end
 
   def test_records_are_parse_correctly
     site.generate
     assert_equal 'Edward G. Cross', site.data['education'].first['name']
+    assert_equal 'Edward G. Cross', site.collections['education'].docs.first.data['name']
   end
 
   def test_adding_another_collection
     site.config['remote_csv']['foo_bar'] = site.config['remote_csv']['education']
     site.generate
     assert_equal 9, site.data['education'].size
+    assert_equal 9, site.collections['education'].docs.size
     assert_equal 9, site.data['foo_bar'].size
+    assert_equal 9, site.collections['foo_bar'].docs.size
   end
 
   def test_collections_are_populated
@@ -75,5 +80,11 @@ class Jekyll::RemoteCsvTest < Minitest::Test
 
   def test_it_has_a_low_priority
     assert_equal :low, Jekyll::RemoteCsv::Generator.priority
+  end
+
+  def test_turning_csv_into_collection
+    site.generate
+    refute_nil site.collections['education']
+    assert_equal 9, site.collections['education'].docs.size
   end
 end

--- a/test/jekyll/remote_csv_test.rb
+++ b/test/jekyll/remote_csv_test.rb
@@ -27,28 +27,23 @@ class Jekyll::RemoteCsvTest < Minitest::Test
 
   def test_it_populates_site_data_with_education
     site.generate
-    refute_nil site.data['education']
     refute_nil site.collections['education']
   end
 
   def test_the_correct_number_of_records_exist
     site.generate
-    assert_equal 9, site.data['education'].size
     assert_equal 9, site.collections['education'].docs.size
   end
 
   def test_records_are_parse_correctly
     site.generate
-    assert_equal 'Edward G. Cross', site.data['education'].first['name']
     assert_equal 'Edward G. Cross', site.collections['education'].docs.first.data['name']
   end
 
   def test_adding_another_collection
     site.config['remote_csv']['foo_bar'] = site.config['remote_csv']['education']
     site.generate
-    assert_equal 9, site.data['education'].size
     assert_equal 9, site.collections['education'].docs.size
-    assert_equal 9, site.data['foo_bar'].size
     assert_equal 9, site.collections['foo_bar'].docs.size
   end
 
@@ -86,5 +81,12 @@ class Jekyll::RemoteCsvTest < Minitest::Test
     site.generate
     refute_nil site.collections['education']
     assert_equal 9, site.collections['education'].docs.size
+  end
+
+  def test_collection_slug_field
+    site.config['remote_csv']['education']['collection_slug_field'] = 'organisation_name'
+    site.generate
+    doc = site.collections['education'].docs.first
+    assert_equal 'gwebi-agricultural-college', doc.basename_without_ext
   end
 end


### PR DESCRIPTION
Rather than adding things to `site.data` we create a collection for each source CSV. This means that they gain all the nice-ness that collections have such as being able to be output at a url.
