### PR TITLE
Group by option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,54 @@ collections:
 
 With the above configuration the education source CSV will be turned into a collection and then each item in the collection will be output at `/education/organisation-name-slugified`.
 
+### Grouping records
+
+Sometimes you might want to group the records by a certain field, perhaps you want to display all the people who went to Harvard University for example. To make this work you can specify a `group_by` option:
+
+```yaml
+remote_csv:
+  education:
+    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
+    group_by: university
+
+collections:
+  education_by_university:
+    output: true
+```
+
+Then in your `_layouts/education_by_university.html` file:
+
+```liquid
+<h1>{{ page.title }}</h1>
+{% for education in page.education %}
+  <p>{{ education.name }}</p>
+  <p>{{ education.degree }}</p>
+{% endfor %}
+```
+
+If you want to connect back to another collection you can also specify a `reverse_relation_name` option:
+
+```yaml
+remote_csv:
+  education:
+    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
+    group_by: university
+    reverse_relation_name: person
+    collections:
+      people: person_id
+
+collections:
+  education_by_university:
+    output: true
+```
+
+```liquid
+<h1>{{ page.title }}</h1>
+{% for education in page.education %}
+  <p><a href="{{ education.person.url }}">{{ education.person.name }}</a></p>
+  <p>{{ education.degree }}</p>
+{% endfor %}
+```
 
 ## Development
 

--- a/lib/jekyll/remote_csv.rb
+++ b/lib/jekyll/remote_csv.rb
@@ -16,6 +16,15 @@ module Jekyll
           csv_string = open(conf['source']).read
           csv_data = CSV.parse(csv_string, headers: true).map(&:to_hash)
           site.collections[source_name] = make_collection(site, source_name, conf, csv_data)
+          if conf['group_by']
+            group_name = "#{source_name}_by_#{conf['group_by']}"
+            site.collections[group_name] = make_group_collection(site, source_name, group_name, conf, site.collections[source_name].docs)
+            site.collections[source_name].docs.each do |doc|
+              doc.data[group_name] = site.collections[group_name].docs.find do |group|
+                group['title'] == doc[conf['group_by']]
+              end
+            end
+          end
           next unless conf['collections']
           conf['collections'].each do |collection_name, key|
             next unless site.collections.key?(collection_name)
@@ -26,8 +35,8 @@ module Jekyll
                 item[csv_id_field] == doc[key]
               end
               doc.data[source_name].each do |source_doc|
-                source_doc.data[collection_name] ||= []
-                source_doc.data[collection_name] << doc
+                reverse_relation_name = conf.fetch('reverse_relation_name', collection_name)
+                source_doc.data[reverse_relation_name] = doc
               end
             end
           end
@@ -42,6 +51,22 @@ module Jekyll
           doc = Document.new(path, collection: collection, site: site)
           doc.merge_data!(item)
           if site.layouts.key?(source_name)
+            doc.merge_data!('layout' => source_name)
+          end
+          collection.docs << doc
+        end
+        collection
+      end
+
+      def make_group_collection(site, source_name, group_name, conf, data)
+        collection = Collection.new(site, group_name)
+        data.group_by { |d| d[conf['group_by']] }.each do |name, items|
+          path = File.join(site.source, "_#{group_name}", "#{Jekyll::Utils.slugify(name)}.md")
+          doc = Document.new(path, collection: collection, site: site)
+          doc.merge_data!('title' => name, source_name => items)
+          if site.layouts.key?(group_name)
+            doc.merge_data!('layout' => group_name)
+          elsif site.layouts.key?(source_name)
             doc.merge_data!('layout' => source_name)
           end
           collection.docs << doc

--- a/test/jekyll/remote_csv_test.rb
+++ b/test/jekyll/remote_csv_test.rb
@@ -89,4 +89,16 @@ class Jekyll::RemoteCsvTest < Minitest::Test
     doc = site.collections['education'].docs.first
     assert_equal 'gwebi-agricultural-college', doc.basename_without_ext
   end
+
+  def test_group_by
+    site.config['remote_csv']['education']['group_by'] = 'role'
+    site.generate
+    refute_nil site.collections['education_by_role']
+    doc = site.collections['education_by_role'].docs.find { |er| er['title'] == 'Bachelor of Laws (LLB)' }
+    refute_nil doc
+    assert_equal 2, doc['education'].length
+    edu_doc = doc['education'].first
+    refute_nil edu_doc
+    assert_equal 'Bachelor of Laws (LLB)', edu_doc['education_by_role']['title']
+  end
 end


### PR DESCRIPTION
Allows you to group rows from the remote csv by one of the columns. This can be useful for displaying all the people who went to a certain university or all the people who held a certain position.
