### PR TITLE
Fix example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In this default configuration it will fetch the CSV at the url specified in the 
 
 ```liquid
 {% for item in site.education %}
-  <p>{{ item.role }}</p>
+  <p>{{ item.name }}</p>
 {% endfor %}
 ```
 


### PR DESCRIPTION
The example CSV doesn't contain a role field, so nothing will be
rendered. Instead use the name field.
