### PR TITLE
Remove joins and grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jekyll::RemoteCsv [![Build Status](https://travis-ci.org/everypolitician/jekyll-remote_csv.svg?branch=master)](https://travis-ci.org/everypolitician/jekyll-remote_csv)
 
-This plugin allows you to specify remote CSVs to be turned into collections. It also provides a way for you to associate these collections with other collections.
+This plugin takes a path or URL to a CSV file and uses the data to populate a [Jekyll Collection](https://jekyllrb.com/docs/collections/).
 
 ## Installation
 
@@ -36,46 +36,6 @@ In this default configuration it will fetch the CSV at the url specified in the 
 {% endfor %}
 ```
 
-### Associating with other collections
-
-Sometimes you might want this collection to be associated with another collection, you can configure this in `_config.yml`:
-
-```yaml
-remote_csv:
-  education:
-    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
-    collections:
-      - assembly_people
-      - senate_people
-```
-
-This will associate the collection in the source CSV with the `assembly_people` and `senate_people` collections. For this to work correctly each document in the collections will need to specify an `id` in its frontmatter which matches the `id` column in the CSV. If you need to override this then you can specify that:
-
-```yaml
-remote_csv:
-  education:
-    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
-    csv_id_field: person_id
-    collections:
-      assembly_people: pombola_id
-      senate_people: kuvakazim_id
-```
-
-This will use the `person_id` column in the CSV and match it to `assembly_people` using the `pombola_id` property in the frontmatter and the `senate_people` using the `kuvakazim_id` property. This means that each person in the collection will have an `education` property.
-
-Assuming that the CSV file has `person_id`, `organization_name` and `qualification` columns you could then use this in a template listing people as follows:
-
-```liquid
-{% for person in site.assembly_people %}
-  <h2>{{ person.name }} Education</h2>
-  <ul>
-  {% for education in person.education %}
-    <li>Organisation: {{ education.organization_name }} | Qualification: {{ education.qualification }}</li>
-  {% endfor %}
-  </ul>
-{% endfor %}
-```
-
 ### Outputting a collection
 
 If you want to output the collection then you will need to provide a key to use for the output item's slug.
@@ -92,55 +52,6 @@ collections:
 ```
 
 With the above configuration the education source CSV will be turned into a collection and then each item in the collection will be output at `/education/organisation-name-slugified`.
-
-### Grouping records
-
-Sometimes you might want to group the records by a certain field, perhaps you want to display all the people who went to Harvard University for example. To make this work you can specify a `group_by` option:
-
-```yaml
-remote_csv:
-  education:
-    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
-    group_by: university
-
-collections:
-  education_by_university:
-    output: true
-```
-
-Then in your `_layouts/education_by_university.html` file:
-
-```liquid
-<h1>{{ page.title }}</h1>
-{% for education in page.education %}
-  <p>{{ education.name }}</p>
-  <p>{{ education.degree }}</p>
-{% endfor %}
-```
-
-If you want to connect back to another collection you can also specify a `reverse_relation_name` option:
-
-```yaml
-remote_csv:
-  education:
-    source: https://docs.google.com/spreadsheets/u/1/d/1rFnkM9rrhwmo5eTwhEPordgucf-iNACnzc6E78elkaM/export?format=csv
-    group_by: university
-    reverse_relation_name: person
-    collections:
-      people: person_id
-
-collections:
-  education_by_university:
-    output: true
-```
-
-```liquid
-<h1>{{ page.title }}</h1>
-{% for education in page.education %}
-  <p><a href="{{ education.person.url }}">{{ education.person.name }}</a></p>
-  <p>{{ education.degree }}</p>
-{% endfor %}
-```
 
 ## Development
 

--- a/lib/jekyll/remote_csv.rb
+++ b/lib/jekyll/remote_csv.rb
@@ -16,30 +16,6 @@ module Jekyll
           csv_string = open(conf['source']).read
           csv_data = CSV.parse(csv_string, headers: true).map(&:to_hash)
           site.collections[source_name] = make_collection(site, source_name, conf, csv_data)
-          if conf['group_by']
-            group_name = "#{source_name}_by_#{conf['group_by']}"
-            site.collections[group_name] = make_group_collection(site, source_name, group_name, conf, site.collections[source_name].docs)
-            site.collections[source_name].docs.each do |doc|
-              doc.data[group_name] = site.collections[group_name].docs.find do |group|
-                group['title'] == doc[conf['group_by']]
-              end
-            end
-          end
-          next unless conf['collections']
-          conf['collections'].each do |collection_name, key|
-            next unless site.collections.key?(collection_name)
-            key ||= 'id'
-            csv_id_field = conf.fetch('csv_id_field', 'id')
-            site.collections[collection_name].docs.each do |doc|
-              doc.data[source_name] = site.collections[source_name].docs.find_all do |item|
-                item[csv_id_field] == doc[key]
-              end
-              doc.data[source_name].each do |source_doc|
-                reverse_relation_name = conf.fetch('reverse_relation_name', collection_name)
-                source_doc.data[reverse_relation_name] = doc
-              end
-            end
-          end
         end
       end
 
@@ -51,22 +27,6 @@ module Jekyll
           doc = Document.new(path, collection: collection, site: site)
           doc.merge_data!(item)
           if site.layouts.key?(source_name)
-            doc.merge_data!('layout' => source_name)
-          end
-          collection.docs << doc
-        end
-        collection
-      end
-
-      def make_group_collection(site, source_name, group_name, conf, data)
-        collection = Collection.new(site, group_name)
-        data.group_by { |d| d[conf['group_by']] }.each do |name, items|
-          path = File.join(site.source, "_#{group_name}", "#{Jekyll::Utils.slugify(name)}.md")
-          doc = Document.new(path, collection: collection, site: site)
-          doc.merge_data!('title' => name, source_name => items)
-          if site.layouts.key?(group_name)
-            doc.merge_data!('layout' => group_name)
-          elsif site.layouts.key?(source_name)
             doc.merge_data!('layout' => source_name)
           end
           collection.docs << doc

--- a/test/jekyll/remote_csv_test.rb
+++ b/test/jekyll/remote_csv_test.rb
@@ -30,12 +30,13 @@ class Jekyll::RemoteCsvTest < Minitest::Test
     refute_nil site.collections['education']
   end
 
-  def test_the_correct_number_of_records_exist
+  def test_turning_csv_into_collection
     site.generate
+    refute_nil site.collections['education']
     assert_equal 9, site.collections['education'].docs.size
   end
 
-  def test_records_are_parse_correctly
+  def test_records_are_parsed_correctly
     site.generate
     assert_equal 'Edward G. Cross', site.collections['education'].docs.first.data['name']
   end
@@ -47,40 +48,8 @@ class Jekyll::RemoteCsvTest < Minitest::Test
     assert_equal 9, site.collections['foo_bar'].docs.size
   end
 
-  def test_collections_are_populated
-    add_people_collection_to_site
-    site.config['remote_csv']['education']['collections'] = [
-      'people'
-    ]
-    site.generate
-    person = site.collections['people'].docs.first
-    refute_nil person['education']
-    assert_equal 'University of Zimbabwe', person['education'].first['organisation_name']
-  end
-
-  def test_overriding_csv_id_field
-    add_people_collection_to_site
-    site.config['remote_csv'] = {
-      'education' => {
-        'source' => 'test/fixtures/education_person_id.csv',
-        'csv_id_field' => 'person_id',
-        'collections' => ['people']
-      }
-    }
-    site.generate
-    person = site.collections['people'].docs.first
-    refute_nil person['education']
-    assert_equal 'University of Zimbabwe', person['education'].first['organisation_name']
-  end
-
   def test_it_has_a_low_priority
     assert_equal :low, Jekyll::RemoteCsv::Generator.priority
-  end
-
-  def test_turning_csv_into_collection
-    site.generate
-    refute_nil site.collections['education']
-    assert_equal 9, site.collections['education'].docs.size
   end
 
   def test_collection_slug_field
@@ -88,17 +57,5 @@ class Jekyll::RemoteCsvTest < Minitest::Test
     site.generate
     doc = site.collections['education'].docs.first
     assert_equal 'gwebi-agricultural-college', doc.basename_without_ext
-  end
-
-  def test_group_by
-    site.config['remote_csv']['education']['group_by'] = 'role'
-    site.generate
-    refute_nil site.collections['education_by_role']
-    doc = site.collections['education_by_role'].docs.find { |er| er['title'] == 'Bachelor of Laws (LLB)' }
-    refute_nil doc
-    assert_equal 2, doc['education'].length
-    edu_doc = doc['education'].first
-    refute_nil edu_doc
-    assert_equal 'Bachelor of Laws (LLB)', edu_doc['education_by_role']['title']
   end
 end


### PR DESCRIPTION
To make this plugin easier to reason about I've removed the ORM-ish features of grouping by a certain field and joining between collections. Other plugins can implement those features by building on top of this plugin.
